### PR TITLE
mtp-server: don't throw an error if /dev/mtp_usb is unavailable.

### DIFF
--- a/server/server.cpp
+++ b/server/server.cpp
@@ -20,7 +20,9 @@
 #include <MtpServer.h>
 #include <MtpStorage.h>
 
+#include <chrono>
 #include <iostream>
+#include <thread>
 #include <stdint.h>
 
 #include <signal.h>
@@ -289,10 +291,10 @@ int main(int argc, char** argv)
     LOG(INFO) << "MTP server starting...";
 
     int fd = open("/dev/mtp_usb", O_RDWR);
-    if (fd < 0)
-    {
-        LOG(ERROR) << "Error opening /dev/mtp_usb, aborting now...";
-        return 1;
+    while (fd < 0) {
+        LOG(INFO) << "Couldn't open /dev/mtp_usb, waiting for device...";
+        std::this_thread::sleep_for(std::chrono::milliseconds(5000));
+        fd = open("/dev/mtp_usb", O_RDWR);
     }
 
     try {


### PR DESCRIPTION
On some devices, e.g. Volla 22, sometimes /dev/mtp_usb is not available. If this is the case and mtp-server.service tries to start, it will error out immediately and keep restarting the service indefinitely, causing unnecessary spam in the journal.
Now instead of throwing an error, just wait for /dev/mtp_usb to appear and then continue as normal when it does.