### PR TITLE
Drop daemon functionality, switch to systemd multi-instances

### DIFF
--- a/debian/mtp-server.dirs
+++ b/debian/mtp-server.dirs
@@ -1,0 +1,1 @@
+/var/lib/droidian

--- a/debian/mtp-server.mtp-configfs.service
+++ b/debian/mtp-server.mtp-configfs.service
@@ -4,6 +4,7 @@ Requires=lxc@android.service
 After=phosh.service
 
 [Service]
+Type=oneshot
 ExecStartPre=-chown droidian:droidian /dev/mtp_usb
 ExecStart=/usr/sbin/mtp-configfs
 

--- a/debian/mtp-server.mtp-configfs@.service
+++ b/debian/mtp-server.mtp-configfs@.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=usb state change: to %i
 Requires=lxc@android.service
-After=phosh.service
+After=android_boot_completed.service
 
 [Service]
 Type=oneshot

--- a/debian/mtp-server.mtp-configfs@.service
+++ b/debian/mtp-server.mtp-configfs@.service
@@ -6,6 +6,10 @@ After=phosh.service
 [Service]
 Type=oneshot
 ExecStartPre=-chown droidian:droidian /dev/mtp_usb
+ExecStartPre=-rm -f /etc/systemd/system/graphical.target.wants/mtp-configfs@none.service
+ExecStartPre=-rm -f /etc/systemd/system/graphical.target.wants/mtp-configfs@mtp.service
+ExecStartPre=-rm -f /etc/systemd/system/graphical.target.wants/mtp-configfs@rndis.service
+ExecStartPre=-ln -sf /usr/lib/systemd/system/mtp-configfs@.service /etc/systemd/system/graphical.target.wants/mtp-configfs@%i.service
 ExecStart=/usr/sbin/mtp-configfs %i
 
 [Install]

--- a/debian/mtp-server.mtp-configfs@.service
+++ b/debian/mtp-server.mtp-configfs@.service
@@ -1,12 +1,12 @@
 [Unit]
-Description=manage state changes between rndis and mtp
+Description=usb state change: to %i
 Requires=lxc@android.service
 After=phosh.service
 
 [Service]
 Type=oneshot
 ExecStartPre=-chown droidian:droidian /dev/mtp_usb
-ExecStart=/usr/sbin/mtp-configfs
+ExecStart=/usr/sbin/mtp-configfs %i
 
 [Install]
 WantedBy=graphical.target

--- a/debian/mtp-server.postinst
+++ b/debian/mtp-server.postinst
@@ -1,0 +1,49 @@
+#!/bin/sh
+
+#DEBHELPER#
+
+configure() {
+	# Ensure configuration files are owned and writable by root.
+	# This was not the case previously
+	for file in /usr/lib/droidian/device/mtp-configfs.conf /etc/mtp-configfs.conf; do
+		if [ -e ${file} ]; then
+			chown root:root ${file}
+			chmod 644 ${file}
+		fi
+	done
+
+	# Migrate to the new multi-instance service
+	if [ ! -e /var/lib/droidian/mtp-configfs-instance-migration-done ]; then
+		USBMODE=$(grep USBMODE= /usr/lib/droidian/device/mtp-configfs.conf /etc/mtp-configfs.conf 2>/dev/null | cut -d'=' -f2 | sed -e "s|\"||g" -e "s|'||g" | head -n 1)
+		case "${USBMODE}" in
+			rndis|mtp)
+				deb-systemd-helper enable mtp-configfs@${USBMODE}
+				;;
+			none)
+				# Nothing to do
+				;;
+			*)
+				echo "mtp-configfs migration: wrong USBMODE ${USBMODE}" >&2
+				;;
+		esac
+
+		touch /var/lib/droidian/mtp-configfs-instance-migration-done
+	fi
+}
+
+case "${1}" in
+	configure)
+		configure
+		;;
+
+	abort-upgrade|abort-remove|abort-deconfigure)
+		;;
+
+	*)
+		echo "postinst called with unknown argument $1" >&2
+		exit 1
+	;;
+esac
+
+
+exit 0

--- a/debian/rules
+++ b/debian/rules
@@ -12,4 +12,4 @@ override_dh_missing:
 	dh_missing --fail-missing
 
 override_dh_installsystemd:
-	dh_installsystemd -pmtp-server --name=mtp-configfs mtp-configfs.service
+	dh_installsystemd -pmtp-server --no-enable --no-start --name=mtp-configfs@ mtp-configfs@.service

--- a/mtp-configfs/mtp-configfs
+++ b/mtp-configfs/mtp-configfs
@@ -46,6 +46,9 @@ fi
 
 . $CONFIG_FILE
 
+# First argument overrides the USBMODE
+[ -z "${1}" ] || USBMODE="${1}"
+
 if [ "$USBMODE" = "mtp" ]; then
     if [ "$METHOD" = "configfs" ]; then
         if [ ! -e "$GADGETDIR/functions/$MTPCONFIG" ]; then

--- a/mtp-configfs/mtp-configfs
+++ b/mtp-configfs/mtp-configfs
@@ -40,8 +40,6 @@ else
    exit 0
 fi
 
-chown droidian:droidian $CONFIG_FILE
-
 if [ "$METHOD" = "configfs" ]; then
     rm -rf $GADGETDIR/configs/$CONFIGNAME 2> /dev/null
 fi

--- a/mtp-configfs/mtp-configfs
+++ b/mtp-configfs/mtp-configfs
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 CONFIGFS=/sys/kernel/config
 ANDROID_USB=/sys/class/android_usb/android0
@@ -44,7 +44,21 @@ if [ "$METHOD" = "configfs" ]; then
     rm -rf $GADGETDIR/configs/$CONFIGNAME 2> /dev/null
 fi
 
-. $CONFIG_FILE
+while read line; do
+    if ! [[ $line == *=* ]]; then
+        continue
+    fi
+    declare \
+        $(echo "$line" | cut -d= -f1)=$(
+            echo "$line" | \
+            cut -d= -f2- | \
+            sed -e "s|\$CONFIGFS|$CONFIGFS|g" \
+                -e "s|\${CONFIGFS}|$CONFIGFS|g" \
+                -e "s|\$CONFIGDIR|$CONFIGDIR|g" \
+                -e "s|\${CONFIGDIR}|$CONFIGDIR|g" \
+                -e "s|\"||g" \
+                -e "s|'||g")
+done < $CONFIG_FILE
 
 # First argument overrides the USBMODE
 [ -z "${1}" ] || USBMODE="${1}"

--- a/mtp-configfs/mtp-configfs
+++ b/mtp-configfs/mtp-configfs
@@ -44,201 +44,194 @@ if [ "$METHOD" = "configfs" ]; then
     rm -rf $GADGETDIR/configs/$CONFIGNAME 2> /dev/null
 fi
 
-while true; do
-    . $CONFIG_FILE
+. $CONFIG_FILE
 
-    if [ "$USBMODE" != "$OLD_USBMODE" ]; then
-        if [ "$USBMODE" = "mtp" ]; then
-            if [ "$METHOD" = "configfs" ]; then
-                if [ ! -e "$GADGETDIR/functions/$MTPCONFIG" ]; then
-                    if ! mount | grep -q "$CONFIGFS"; then
-                        mount -t configfs none $CONFIGFS
-                        mkdir -p $GADGETDIR/strings/0x409
-                        mkdir -p $GADGETDIR/functions/$RNDISCONFIG
-                        mkdir -p $GADGETDIR/functions/rndis.usb0
-                        mkdir -p $GADGETDIR/functions/rndis_bam.rndis
-                        mkdir -p $GADGETDIR/configs/$CONFIGNAME/strings/0x409
-                    fi
-
-                    printf "$IDVENDOR" > $GADGETDIR/idVendor
-                    printf "$IDPRODUCT" > $GADGETDIR/idProduct
-                    printf "$BCDDEVICE" > $GADGETDIR/bcdDevice
-                    printf "$BCDUSB" > $GADGETDIR/bcdUSB
-                    printf "1" > $GADGETDIR/os_desc/use
-                    printf "0x1" > $GADGETDIR/os_desc/b_vendor_code
-                    printf "MSFT100" > $GADGETDIR/os_desc/qw_sign
-                    printf "$SERIALNUMBER" > $GADGETDIR/strings/0x409/serialnumber
-                    printf "$MANUFACTURER" > $GADGETDIR/strings/0x409/manufacturer
-                    printf "$PRODUCT" > $GADGETDIR/strings/0x409/product
-
-                    mkdir -p $GADGETDIR/functions/$MTPCONFIG
-                    ln -s $GADGETDIR/configs/$CONFIGNAME $GADGETDIR/os_desc/$CONFIGNAME
-
-                    chown root:plugdev $GADGETDIR
-                    chown root:plugdev $GADGETDIR/configs
-                    chown root:plugdev $GADGETDIR/configs/$CONFIGNAME
-
-                    chown root:plugdev /dev/mtp_usb
-                    chmod 660 /dev/mtp_usb
-                fi
-
-                rm -f $GADGETDIR/configs/$CONFIGNAME/$MTPCONFIG
-                rm -f $GADGETDIR/configs/$CONFIGNAME/$RNDISCONFIG
-                rm -f $GADGETDIR/configs/$CONFIGNAME/rndis.usb0
-                rm -f $GADGETDIR/configs/$CONFIGNAME/rndis_bam.rndis
-
-                printf "$USBMODE" > $GADGETDIR/functions/$MTPCONFIG/os_desc/interface.MTP/compatible_id
-                if [ "$IS_EXYNOS" = "true" ]; then
-                    printf "Conf 1" > $GADGETDIR/configs/c.1/strings/0x409/configuration
-                    printf "0x3f" > $GADGETDIR/configs/c.1/MaxPower
-                else
-                    printf "$USBMODE" > $GADGETDIR/configs/$CONFIGNAME/strings/0x409/configuration
-                fi
-
-                ln -s $GADGETDIR/functions/$MTPCONFIG $GADGETDIR/configs/$CONFIGNAME
-                printf "1" > $GADGETDIR/os_desc/use
-                if [ "$IS_EXYNOS" = "true" ]; then
-                    printf "0" > $ANDROID_USB/enable
-                    printf "0x6860" > $GADGETDIR/idProduct
-                    printf "0x04E8" > $GADGETDIR/idVendor
-                    printf "mtp,acm" > $ANDROID_USB/functions
-                    printf "0" > $GADGETDIR/bDeviceClass
-                    printf "$CONTROLLER" > $GADGETDIR/UDC
-                    printf "1" > $ANDROID_USB/enable
-                else
-                    printf "$CONTROLLER" > $GADGETDIR/UDC
-                fi
-            elif [ "$METHOD" = "android_usb" ]; then
-                printf "0" > $ANDROID_USB/enable
-                printf "" > $ANDROID_USB/functions
-                printf "1" > $ANDROID_USB/enable
-                printf "0" > $ANDROID_USB/enable
-                printf "$IDVENDOR" > $ANDROID_USB/idVendor
-                printf "$IDPRODUCT" > $ANDROID_USB/idProduct
-                printf "$MANUFACTURER" > $ANDROID_USB/iManufacturer
-                printf "$PRODUCT" > $ANDROID_USB/iProduct
-                printf "$SERIALNUMBER" > $ANDROID_USB/iSerial
-                printf "0" > $ANDROID_USB/bDeviceClass
-                printf "0" > $ANDROID_USB/bDeviceSubClass
-                printf "0" > $ANDROID_USB/bDeviceProtocol
-                printf "mtp" > $ANDROID_USB/functions
-                printf "1" > $ANDROID_USB/enable
-            fi
-
-            setprop sys.usb.state $USBMODE
-
-            echo "Configured for $USBMODE"
-        elif [ "$USBMODE" = "rndis" ]; then
-            if [ "$METHOD" = "configfs" ]; then
-                rm -f $GADGETDIR/configs/$CONFIGNAME/$MTPCONFIG
-                rm -f $GADGETDIR/configs/$CONFIGNAME/$RNDISCONFIG
-                rm -f $GADGETDIR/configs/$CONFIGNAME/rndis.usb0
-                rm -f $GADGETDIR/configs/$CONFIGNAME/rndis_bam.rndis
-                rm -f $GADGETDIR/configs/$CONFIGNAME/rndis.0
-
+if [ "$USBMODE" = "mtp" ]; then
+    if [ "$METHOD" = "configfs" ]; then
+        if [ ! -e "$GADGETDIR/functions/$MTPCONFIG" ]; then
+            if ! mount | grep -q "$CONFIGFS"; then
+                mount -t configfs none $CONFIGFS
+                mkdir -p $GADGETDIR/strings/0x409
+                mkdir -p $GADGETDIR/functions/$RNDISCONFIG
                 mkdir -p $GADGETDIR/functions/rndis.usb0
                 mkdir -p $GADGETDIR/functions/rndis_bam.rndis
-                mkdir -p $GADGETDIR/strings/0x409
-
-                printf "0x0FCE" > $GADGETDIR/idVendor
-                printf "0x7169" > $GADGETDIR/idProduct
-                printf "$SERIALNUMBER" > $GADGETDIR/strings/0x409/serialnumber
-                printf "$MANUFACTURER" > $GADGETDIR/strings/0x409/manufacturer
-                printf "$PRODUCT" > $GADGETDIR/strings/0x409/product
-
                 mkdir -p $GADGETDIR/configs/$CONFIGNAME/strings/0x409
-
-                if [ "$IS_EXYNOS" = "true" ]; then
-                    printf "Conf 1" > $GADGETDIR/configs/c.1/strings/0x409/configuration
-                    printf "0x3f" > $GADGETDIR/configs/c.1/MaxPower
-                else
-                    printf "$USBMODE" > $GADGETDIR/configs/$CONFIGNAME/strings/0x409/configuration
-                fi
-
-                ln -s $GADGETDIR/functions/rndis.usb0 $GADGETDIR/configs/$CONFIGNAME
-                ln -s $GADGETDIR/functions/rndis_bam.rndis $GADGETDIR/configs/$CONFIGNAME
-                ln -s $GADGETDIR/functions/rndis.0 $GADGETDIR/configs/$CONFIGNAME/rndis.0
-
-                if [ "$IS_EXYNOS" = "true" ]; then
-                    printf "0" > $ANDROID_USB/enable
-                    printf "0x6863" > $GADGETDIR/idProduct
-                    printf "0x04E8" > $GADGETDIR/idVendor
-                    printf "rndis" > $ANDROID_USB/functions
-                    printf "0" > $GADGETDIR/bDeviceClass
-                    printf "$CONTROLLER" > $GADGETDIR/UDC
-                    printf "1" > $ANDROID_USB/enable
-                else
-                    printf "$CONTROLLER" > $GADGETDIR/UDC
-                fi
-            elif [ "$METHOD" = "android_usb" ]; then
-                printf "0" > $ANDROID_USB/enable
-                printf "" > $ANDROID_USB/functions
-                printf "1" > $ANDROID_USB/enable
-                printf "0" > $ANDROID_USB/enable
-                printf "$IDVENDOR" > $ANDROID_USB/idVendor
-                printf "$IDPRODUCT" > $ANDROID_USB/idProduct
-                printf "$MANUFACTURER" > $ANDROID_USB/iManufacturer
-                printf "$PRODUCT" > $ANDROID_USB/iProduct
-                printf "$SERIALNUMBER" > $ANDROID_USB/iSerial
-                printf "239" > $ANDROID_USB/bDeviceClass
-                printf "2" > $ANDROID_USB/bDeviceSubClass
-                printf "1" > $ANDROID_USB/bDeviceProtocol
-                printf "rndis" > $ANDROID_USB/functions
-                printf "1" > $ANDROID_USB/enable
             fi
 
-            setprop sys.usb.state $USBMODE
+            printf "$IDVENDOR" > $GADGETDIR/idVendor
+            printf "$IDPRODUCT" > $GADGETDIR/idProduct
+            printf "$BCDDEVICE" > $GADGETDIR/bcdDevice
+            printf "$BCDUSB" > $GADGETDIR/bcdUSB
+            printf "1" > $GADGETDIR/os_desc/use
+            printf "0x1" > $GADGETDIR/os_desc/b_vendor_code
+            printf "MSFT100" > $GADGETDIR/os_desc/qw_sign
+            printf "$SERIALNUMBER" > $GADGETDIR/strings/0x409/serialnumber
+            printf "$MANUFACTURER" > $GADGETDIR/strings/0x409/manufacturer
+            printf "$PRODUCT" > $GADGETDIR/strings/0x409/product
 
-            pkill dhcpd
-            ifconfig rndis0 10.15.19.82 netmask 255.255.255.0
+            mkdir -p $GADGETDIR/functions/$MTPCONFIG
+            ln -s $GADGETDIR/configs/$CONFIGNAME $GADGETDIR/os_desc/$CONFIGNAME
 
-            mkdir -p /run/hybris-usb
-            touch /run/hybris-usb/dhcpd4.lease
-            dhcpd -f -4 -q -cf /etc/hybris-usb/dhcpd.conf -pf /run/hybris-usb/dhcpd4.pid -lf /run/hybris-usb/dhcpd4.lease &
+            chown root:plugdev $GADGETDIR
+            chown root:plugdev $GADGETDIR/configs
+            chown root:plugdev $GADGETDIR/configs/$CONFIGNAME
 
-            echo "Configured for $USBMODE"
-        elif [ "$USBMODE" = "none" ]; then
-            if [ "$METHOD" = "configfs" ]; then
-                rm -f $GADGETDIR/configs/$CONFIGNAME/$MTPCONFIG
-                rm -f $GADGETDIR/configs/$CONFIGNAME/$RNDISCONFIG
-                rm -f $GADGETDIR/configs/$CONFIGNAME/rndis.usb0
-                rm -f $GADGETDIR/configs/$CONFIGNAME/rndis_bam.rndis
-                rm -f $GADGETDIR/configs/$CONFIGNAME/rndis.0
-            elif [ "$METHOD" = "android_usb" ]; then
-                printf "0" > $ANDROID_USB/enable
-                printf "" > $ANDROID_USB/functions
-                printf "1" > $ANDROID_USB/enable
-                printf "0" > $ANDROID_USB/enable
-                printf "0" > $ANDROID_USB/bDeviceClass
-                printf "0" > $ANDROID_USB/bDeviceSubClass
-                printf "0" > $ANDROID_USB/bDeviceProtocol
-            fi
-
-            setprop sys.usb.state ""
-
-            echo "Configured for $USBMODE"
+            chown root:plugdev /dev/mtp_usb
+            chmod 660 /dev/mtp_usb
         fi
 
-        target_error=$(readlink /tmp/mtp-server.ERROR)
-        target_info=$(readlink /tmp/mtp-server.INFO)
-        target_warning=$(readlink /tmp/mtp-server.WARNING)
+        rm -f $GADGETDIR/configs/$CONFIGNAME/$MTPCONFIG
+        rm -f $GADGETDIR/configs/$CONFIGNAME/$RNDISCONFIG
+        rm -f $GADGETDIR/configs/$CONFIGNAME/rndis.usb0
+        rm -f $GADGETDIR/configs/$CONFIGNAME/rndis_bam.rndis
 
-        for file in /tmp/mtp-server.*; do
-            if [ -L "$file" ]; then
-                continue
-            fi
+        printf "$USBMODE" > $GADGETDIR/functions/$MTPCONFIG/os_desc/interface.MTP/compatible_id
+        if [ "$IS_EXYNOS" = "true" ]; then
+            printf "Conf 1" > $GADGETDIR/configs/c.1/strings/0x409/configuration
+            printf "0x3f" > $GADGETDIR/configs/c.1/MaxPower
+        else
+            printf "$USBMODE" > $GADGETDIR/configs/$CONFIGNAME/strings/0x409/configuration
+        fi
 
-            if [ "$file" = "/tmp/$target_error" ] || [ "$file" = "/tmp/$target_info" ] || [ "$file" = "/tmp/$target_warning" ]; then
-                continue
-            fi
-
-            rm -f "$file"
-        done
-
-        OLD_USBMODE=$USBMODE
+        ln -s $GADGETDIR/functions/$MTPCONFIG $GADGETDIR/configs/$CONFIGNAME
+        printf "1" > $GADGETDIR/os_desc/use
+        if [ "$IS_EXYNOS" = "true" ]; then
+            printf "0" > $ANDROID_USB/enable
+            printf "0x6860" > $GADGETDIR/idProduct
+            printf "0x04E8" > $GADGETDIR/idVendor
+            printf "mtp,acm" > $ANDROID_USB/functions
+            printf "0" > $GADGETDIR/bDeviceClass
+            printf "$CONTROLLER" > $GADGETDIR/UDC
+            printf "1" > $ANDROID_USB/enable
+        else
+            printf "$CONTROLLER" > $GADGETDIR/UDC
+        fi
+    elif [ "$METHOD" = "android_usb" ]; then
+        printf "0" > $ANDROID_USB/enable
+        printf "" > $ANDROID_USB/functions
+        printf "1" > $ANDROID_USB/enable
+        printf "0" > $ANDROID_USB/enable
+        printf "$IDVENDOR" > $ANDROID_USB/idVendor
+        printf "$IDPRODUCT" > $ANDROID_USB/idProduct
+        printf "$MANUFACTURER" > $ANDROID_USB/iManufacturer
+        printf "$PRODUCT" > $ANDROID_USB/iProduct
+        printf "$SERIALNUMBER" > $ANDROID_USB/iSerial
+        printf "0" > $ANDROID_USB/bDeviceClass
+        printf "0" > $ANDROID_USB/bDeviceSubClass
+        printf "0" > $ANDROID_USB/bDeviceProtocol
+        printf "mtp" > $ANDROID_USB/functions
+        printf "1" > $ANDROID_USB/enable
     fi
 
-    sleep 5
+    setprop sys.usb.state $USBMODE
+
+    echo "Configured for $USBMODE"
+elif [ "$USBMODE" = "rndis" ]; then
+    if [ "$METHOD" = "configfs" ]; then
+        rm -f $GADGETDIR/configs/$CONFIGNAME/$MTPCONFIG
+        rm -f $GADGETDIR/configs/$CONFIGNAME/$RNDISCONFIG
+        rm -f $GADGETDIR/configs/$CONFIGNAME/rndis.usb0
+        rm -f $GADGETDIR/configs/$CONFIGNAME/rndis_bam.rndis
+        rm -f $GADGETDIR/configs/$CONFIGNAME/rndis.0
+
+        mkdir -p $GADGETDIR/functions/rndis.usb0
+        mkdir -p $GADGETDIR/functions/rndis_bam.rndis
+        mkdir -p $GADGETDIR/strings/0x409
+
+        printf "0x0FCE" > $GADGETDIR/idVendor
+        printf "0x7169" > $GADGETDIR/idProduct
+        printf "$SERIALNUMBER" > $GADGETDIR/strings/0x409/serialnumber
+        printf "$MANUFACTURER" > $GADGETDIR/strings/0x409/manufacturer
+        printf "$PRODUCT" > $GADGETDIR/strings/0x409/product
+
+        mkdir -p $GADGETDIR/configs/$CONFIGNAME/strings/0x409
+
+        if [ "$IS_EXYNOS" = "true" ]; then
+            printf "Conf 1" > $GADGETDIR/configs/c.1/strings/0x409/configuration
+            printf "0x3f" > $GADGETDIR/configs/c.1/MaxPower
+        else
+            printf "$USBMODE" > $GADGETDIR/configs/$CONFIGNAME/strings/0x409/configuration
+        fi
+
+        ln -s $GADGETDIR/functions/rndis.usb0 $GADGETDIR/configs/$CONFIGNAME
+        ln -s $GADGETDIR/functions/rndis_bam.rndis $GADGETDIR/configs/$CONFIGNAME
+        ln -s $GADGETDIR/functions/rndis.0 $GADGETDIR/configs/$CONFIGNAME/rndis.0
+
+        if [ "$IS_EXYNOS" = "true" ]; then
+            printf "0" > $ANDROID_USB/enable
+            printf "0x6863" > $GADGETDIR/idProduct
+            printf "0x04E8" > $GADGETDIR/idVendor
+            printf "rndis" > $ANDROID_USB/functions
+            printf "0" > $GADGETDIR/bDeviceClass
+            printf "$CONTROLLER" > $GADGETDIR/UDC
+            printf "1" > $ANDROID_USB/enable
+        else
+            printf "$CONTROLLER" > $GADGETDIR/UDC
+        fi
+    elif [ "$METHOD" = "android_usb" ]; then
+        printf "0" > $ANDROID_USB/enable
+        printf "" > $ANDROID_USB/functions
+        printf "1" > $ANDROID_USB/enable
+        printf "0" > $ANDROID_USB/enable
+        printf "$IDVENDOR" > $ANDROID_USB/idVendor
+        printf "$IDPRODUCT" > $ANDROID_USB/idProduct
+        printf "$MANUFACTURER" > $ANDROID_USB/iManufacturer
+        printf "$PRODUCT" > $ANDROID_USB/iProduct
+        printf "$SERIALNUMBER" > $ANDROID_USB/iSerial
+        printf "239" > $ANDROID_USB/bDeviceClass
+        printf "2" > $ANDROID_USB/bDeviceSubClass
+        printf "1" > $ANDROID_USB/bDeviceProtocol
+        printf "rndis" > $ANDROID_USB/functions
+        printf "1" > $ANDROID_USB/enable
+    fi
+
+    setprop sys.usb.state $USBMODE
+
+    pkill dhcpd
+    ifconfig rndis0 10.15.19.82 netmask 255.255.255.0
+
+    mkdir -p /run/hybris-usb
+    touch /run/hybris-usb/dhcpd4.lease
+    dhcpd -f -4 -q -cf /etc/hybris-usb/dhcpd.conf -pf /run/hybris-usb/dhcpd4.pid -lf /run/hybris-usb/dhcpd4.lease &
+
+    echo "Configured for $USBMODE"
+elif [ "$USBMODE" = "none" ]; then
+    if [ "$METHOD" = "configfs" ]; then
+        rm -f $GADGETDIR/configs/$CONFIGNAME/$MTPCONFIG
+        rm -f $GADGETDIR/configs/$CONFIGNAME/$RNDISCONFIG
+        rm -f $GADGETDIR/configs/$CONFIGNAME/rndis.usb0
+        rm -f $GADGETDIR/configs/$CONFIGNAME/rndis_bam.rndis
+        rm -f $GADGETDIR/configs/$CONFIGNAME/rndis.0
+    elif [ "$METHOD" = "android_usb" ]; then
+        printf "0" > $ANDROID_USB/enable
+        printf "" > $ANDROID_USB/functions
+        printf "1" > $ANDROID_USB/enable
+        printf "0" > $ANDROID_USB/enable
+        printf "0" > $ANDROID_USB/bDeviceClass
+        printf "0" > $ANDROID_USB/bDeviceSubClass
+        printf "0" > $ANDROID_USB/bDeviceProtocol
+    fi
+
+    setprop sys.usb.state ""
+
+    echo "Configured for $USBMODE"
+fi
+
+target_error=$(readlink /tmp/mtp-server.ERROR)
+target_info=$(readlink /tmp/mtp-server.INFO)
+target_warning=$(readlink /tmp/mtp-server.WARNING)
+
+for file in /tmp/mtp-server.*; do
+    if [ -L "$file" ]; then
+        continue
+    fi
+
+    if [ "$file" = "/tmp/$target_error" ] || [ "$file" = "/tmp/$target_info" ] || [ "$file" = "/tmp/$target_warning" ]; then
+        continue
+    fi
+
+    rm -f "$file"
 done
+
 
 exit 0


### PR DESCRIPTION
This removes the need for the user to modify the configuration file, which was actually a security issue that could lead to privilege escalation.